### PR TITLE
feat: adding nix flake and client build (Linux and Windows)

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -1,0 +1,37 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]        
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixos-25.05
+
+      - name: Build Linux Client
+        run: nix build .#hydrangea-client-linux
+
+      - name: Upload Linux Client Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hydrangea-client-linux
+          path: result
+
+      - name: Build Windows Client
+        run: nix build .#hydrangea-client-windows
+
+      - name: Upload Windows Client Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hydrangea-client-windows
+          path: result

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -1,20 +1,33 @@
-name: CI/CD Pipeline
+name: CI / Release
 
 on:
   push:
     branches: [ main ]
+    tags:    [ 'v*' ]     # créer une release quand on push un tag vX.Y.Z
   pull_request:
     branches: [ main ]
 
 permissions:
-  contents: read
+  contents: write          # nécessaire pour créer la release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-test:
+  build:
+    name: Build (${{ matrix.target.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { name: linux,   flake_attr: hydrangea-client-linux }
+          - { name: windows, flake_attr: hydrangea-client-windows }
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -22,24 +35,45 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build Linux client and capture exact out path (avoid relying on "result" symlink)
-      - id: build-linux
-        name: Build Linux Client
-        run: echo "out=$(nix build .#hydrangea-client-linux --print-out-paths)" >> "$GITHUB_OUTPUT"
+      - id: build
+        name: Nix build (${{ matrix.target.flake_attr }})
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$(nix build ".#${{ matrix.target.flake_attr }}" --print-out-paths)"
+          echo "out=${OUT}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload Linux Client Artifact
+      - id: discover
+        name: Locate produced binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="${{ steps.build.outputs.out }}"
+          BIN_PATH="$(find "${OUT}/bin" -maxdepth 1 -type f -perm -111 | head -n1)"
+          BIN_NAME="$(basename "${BIN_PATH}")"
+          echo "bin_path=${BIN_PATH}" >> "$GITHUB_OUTPUT"
+          echo "bin_name=${BIN_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact (${{ steps.discover.outputs.bin_name }})
         uses: actions/upload-artifact@v4
         with:
-          name: hydrangea-client-linux
-          path: ${{ steps.build-linux.outputs.out }}
+          name: ${{ steps.discover.outputs.bin_name }}
+          path: ${{ steps.discover.outputs.bin_path }}
 
-      # Build Windows client and capture out path
-      - id: build-windows
-        name: Build Windows Client
-        run: echo "out=$(nix build .#hydrangea-client-windows --print-out-paths)" >> "$GITHUB_OUTPUT"
-
-      - name: Upload Windows Client Artifact
-        uses: actions/upload-artifact@v4
+  release:
+    name: Release
+    needs: [ build ]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: hydrangea-client-windows
-          path: ${{ steps.build-windows.outputs.out }}
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          files: artifacts/**/*

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -4,34 +4,42 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]        
+    branches: [ main ]
+
+permissions:
+  contents: read
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v17
+        uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
+          nix_path: nixpkgs=channel:nixos-unstable
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Linux Client
-        run: nix build .#hydrangea-client-linux
+      # Build Linux client and capture exact out path (avoid relying on "result" symlink)
+      - id: build-linux
+        name: Build Linux Client
+        run: echo "out=$(nix build .#hydrangea-client-linux --print-out-paths)" >> "$GITHUB_OUTPUT"
 
       - name: Upload Linux Client Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hydrangea-client-linux
-          path: result
+          path: ${{ steps.build-linux.outputs.out }}
 
-      - name: Build Windows Client
-        run: nix build .#hydrangea-client-windows
+      # Build Windows client and capture out path
+      - id: build-windows
+        name: Build Windows Client
+        run: echo "out=$(nix build .#hydrangea-client-windows --print-out-paths)" >> "$GITHUB_OUTPUT"
 
       - name: Upload Windows Client Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hydrangea-client-windows
-          path: result
+          path: ${{ steps.build-windows.outputs.out }}

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -3,12 +3,12 @@ name: CI / Release
 on:
   push:
     branches: [ main ]
-    tags:    [ 'v*' ]     # créer une release quand on push un tag vX.Y.Z
+    tags:    [ 'v*' ]  
   pull_request:
     branches: [ main ]
 
 permissions:
-  contents: write          # nécessaire pour créer la release
+  contents: write        
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,8 @@ poetry.toml
 # LSP config files
 pyrightconfig.json
 
+# Nix
+result/
+result
+
 # End of https://www.toptal.com/developers/gitignore/api/python

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Hydrangea C2 a quietly elegant command-and-control.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+  let
+    system = "x86_64-linux";
+    version = "0.1.0";
+    pkgs = import nixpkgs { inherit system; };
+    src = ./.;
+
+    mkClient = import ./nix/mkClient.nix { inherit pkgs version src; };
+
+  in
+  {
+    packages.${system} = {
+
+    # --- Linux Client ---
+      hydrangea-client-linux = mkClient "gnu64";
+
+    # --- Windows Client ---
+      hydrangea-client-windows = mkClient "mingwW64";
+
+    # --- Server ---
+    # To do
+
+    # --- ctl ---
+    # To do
+
+    };
+  };
+}

--- a/nix/mkClient.nix
+++ b/nix/mkClient.nix
@@ -15,9 +15,9 @@ target:
     postInstall = ''
       for f in $out/bin/*; do
         if [ "${target}" = "mingwW64" ]; then
-          mv "$f" "$out/bin/hydrangea-client-${target}-${version}.exe"
+          mv "$f" "$out/bin/hydrangea-client-Windows64-${version}.exe"
         else
-          mv "$f" "$out/bin/hydrangea-client-${target}-${version}"
+          mv "$f" "$out/bin/hydrangea-client-Linux64-${version}"
         fi
       done
     '';

--- a/nix/mkClient.nix
+++ b/nix/mkClient.nix
@@ -1,0 +1,32 @@
+{ pkgs, version, src ? ./. }:
+target:
+  pkgs.pkgsCross.${target}.buildGoModule {
+    pname = "hydrangea-client-${target}";
+    inherit version;
+    inherit src;
+    modRoot = "client/go";
+    # Required to unsure dependacy are consistent
+    vendorHash = "sha256-y5DvzFpXa2a2+ZZmM+JUhfjdrxpSR9gIj/JPOvKhAd4=";
+
+    env.CGO_ENABLED = "0";
+
+    dontStrip = true;
+
+    postInstall = ''
+      for f in $out/bin/*; do
+        if [ "${target}" = "mingwW64" ]; then
+          mv "$f" "$out/bin/hydrangea-client-${target}-${version}.exe"
+        else
+          mv "$f" "$out/bin/hydrangea-client-${target}-${version}"
+        fi
+      done
+    '';
+
+    meta = with pkgs.lib; {
+      description = "Hydrangea C2 Go client for ${target} - ${version}";
+      homepage = "https://github.com/tristanqtn/Hydrangea-C2";
+      license = licenses.asl20;
+      platforms = platforms.all;
+      mainProgram = "hydrangea-client-${target}-${version}";
+    };
+  }


### PR DESCRIPTION
# Add Nix flake for reproducible cross-platform builds of the Hydrangea C2 client

## Description

This PR introduces a Nix flake configuration to enable reproducible, cross-platform builds of the Hydrangea C2 client.

## Changes

* Added [flake.nix](flake.nix): main flake configuration defining build targets and dependencies.
* Added [mkClient.nix](nix/mkClient.nix): reusable function for building Go clients across different platforms.

## Features

* [x] Cross-platform support: Linux (`gnu64`) and Windows (`mingwW64`) targets
* [x] Reproducible builds: pinned dependencies with `vendorHash`
* [x] Zero CGO dependencies: `CGO_ENABLED=0` for static binaries
* [x] Versioned outputs: binaries include the version and target in the filename

## Build

```bash
# Build Linux client
nix build .#hydrangea-client-linux

# Build Windows client
nix build .#hydrangea-client-windows

# Build both
nix build .#hydrangea-client-linux .#hydrangea-client-windows
```

> The resulting artifacts are available via the `result*` symlinks created by Nix.

## Future work

### Client distribution

Real value will be added in a follow-up by adding CI/CD to produce and publish artifacts for every OS/architecture supported by Nix cross builds. Current cross sets include (non-exhaustive):

<details>
<summary>Supported <code>pkgsCross</code> examples</summary>

```
pkgsCross.aarch64-android             pkgsCross.musl-power
pkgsCross.aarch64-android-prebuilt    pkgsCross.musl32
pkgsCross.aarch64-darwin              pkgsCross.musl64
pkgsCross.aarch64-embedded            pkgsCross.muslpi
pkgsCross.aarch64-multiplatform       pkgsCross.or1k
pkgsCross.aarch64-multiplatform-musl  pkgsCross.pogoplug4
pkgsCross.aarch64be-embedded          pkgsCross.powernv
pkgsCross.amd64-netbsd                pkgsCross.ppc-embedded
pkgsCross.arm-embedded                pkgsCross.ppc64
pkgsCross.armhf-embedded              pkgsCross.ppc64-musl
pkgsCross.armv7a-android-prebuilt     pkgsCross.ppcle-embedded
pkgsCross.armv7l-hf-multiplatform     pkgsCross.raspberryPi
pkgsCross.avr                         pkgsCross.remarkable1
pkgsCross.ben-nanonote                pkgsCross.remarkable2
pkgsCross.fuloongminipc               pkgsCross.riscv32
pkgsCross.ghcjs                       pkgsCross.riscv32-embedded
pkgsCross.gnu32                       pkgsCross.riscv64
pkgsCross.gnu64                       pkgsCross.riscv64-embedded
pkgsCross.i686-embedded               pkgsCross.scaleway-c1
pkgsCross.iphone32                    pkgsCross.sheevaplug
pkgsCross.iphone32-simulator          pkgsCross.vc4
pkgsCross.iphone64                    pkgsCross.wasi32
pkgsCross.iphone64-simulator          pkgsCross.x86_64-embedded
pkgsCross.mingw32                     pkgsCross.x86_64-netbsd
pkgsCross.mingwW64                    pkgsCross.x86_64-netbsd-llvm
pkgsCross.mmix                        pkgsCross.x86_64-unknown-redox
pkgsCross.msp430
```

</details>

More details: [https://nix.dev/tutorials/cross-compilation.html](https://nix.dev/tutorials/cross-compilation.html)

### Project architecture

Current layout:

```
.
├── client
│   ├── go
│   │   ├── go.mod
│   │   ├── go.sum
│   │   ├── main.go
│   │   ├── revshell_unix.go
│   │   └── revshell_windows.go
│   └── py
│       ├── client.py
│       └── common.py
├── flake.lock
├── flake.nix
├── Hydrangea-ctl.py
├── Hydrangea-server.py
├── LICENSE
├── nix
│   └── mkClient.nix
├── README.md
└── server
    ├── common.py
    ├── go_builder.py
    └── UI.py
```

We currently have three components:

* **Client** (already packaged with Nix)
* **Server**
* **ctl**

The latter two are written in Python and therefore depend on the host’s Python version.

### Refactor proposal

Refactor the codebase into two Python modules, **server** and **ctl**. They would remain runnable with `python` for fast development, while enabling Nix to build architecture- and OS-specific binaries from these modules. This would allow publishing prebuilt binaries for all components on GitHub for quick, easy deployment and use.
